### PR TITLE
Fixing typo and version number

### DIFF
--- a/src/pages/kubernetes/activities/labs/lab6/index.mdx
+++ b/src/pages/kubernetes/activities/labs/lab6/index.mdx
@@ -4,7 +4,7 @@ title: Kubernetes Lab 6 - Rolling Updates
 
 ## Problem
 
-Your company's developers have just finished developing a new version of their jedi-themed mobile game. They are ready to update the backend services that are running in your Kubernetes cluster. There is a deployment in the cluster managing the replicas for this application. The deployment is called `jedi-deployment`. You have been asked to update the image for the container named `jedi-ws` in this deployment template to a new version, `bitnamy/nginx:1.18.1`.
+Your company's developers have just finished developing a new version of their jedi-themed mobile game. They are ready to update the backend services that are running in your Kubernetes cluster. There is a deployment in the cluster managing the replicas for this application. The deployment is called `jedi-deployment`. You have been asked to update the image for the container named `jedi-ws` in this deployment template to a new version, `bitnamy/nginx:1.17`.
 
 After you have updated the image using a rolling update, check on the status of the update to make sure it is working. If it is not working, perform a rollback to the previous state.
 

--- a/src/pages/kubernetes/activities/labs/lab6/index.mdx
+++ b/src/pages/kubernetes/activities/labs/lab6/index.mdx
@@ -4,7 +4,7 @@ title: Kubernetes Lab 6 - Rolling Updates
 
 ## Problem
 
-Your company's developers have just finished developing a new version of their jedi-themed mobile game. They are ready to update the backend services that are running in your Kubernetes cluster. There is a deployment in the cluster managing the replicas for this application. The deployment is called `jedi-deployment`. You have been asked to update the image for the container named `jedi-ws` in this deployment template to a new version, `bitnamy/nginx:1.17`.
+Your company's developers have just finished developing a new version of their jedi-themed mobile game. They are ready to update the backend services that are running in your Kubernetes cluster. There is a deployment in the cluster managing the replicas for this application. The deployment is called `jedi-deployment`. You have been asked to update the image for the container named `jedi-ws` in this deployment template to a new version, `bitnami/nginx:1.17`.
 
 After you have updated the image using a rolling update, check on the status of the update to make sure it is working. If it is not working, perform a rollback to the previous state.
 


### PR DESCRIPTION
According to Dockerhub, the tag `1.18.1` does not exist. So I thought replacing it with 1.17 (one version more recent than the original deployment spec in the exercise)

There was also a typo related to spelling the image name (bitnamy vs bitnami)

https://hub.docker.com/r/bitnami/nginx/