### PR TITLE
brew – no need to add tap for tkn

### DIFF
--- a/src/pages/lectures/continuous-integration/activities/tekton/iks.mdx
+++ b/src/pages/lectures/continuous-integration/activities/tekton/iks.mdx
@@ -19,8 +19,7 @@ Follow the instructions [here](../../prerequisites#environment-setup)
 
 - For MacOS for example you can use brew
     ```bash
-    brew tap tektoncd/tools
-    brew install tektoncd/tools/tektoncd-cli
+    brew install tektoncd-cli
     ```
 - Verify the Tekton cli
     ```bash


### PR DESCRIPTION
Cleaned up brew install of Tekton command line tool from brew 🍺