### PR TITLE
Update index.mdx

### DIFF
--- a/src/pages/concepts/kubernetes/index.mdx
+++ b/src/pages/concepts/kubernetes/index.mdx
@@ -127,7 +127,7 @@ The Managed Lifecycle pattern describes how containers need to adapt their lifec
 
 ### SIGTERM
 
-The SIGTERM is a signal that is sent from the managing platform to a container or pod that instructs the pod or container to shutdown or restart.  This signal can be sent due to a failed liveness test or a failure inside the container.  SIGKILL allows the container to cleaning and properly shut itself down versus SIGKILL, which we will get to next. Once received, the application will shutdown as quickly as it can, allowing other processes to stop properly and cleaning up other files.  Each application will have a different shutdown time based on the tasks needed to be done.
+The SIGTERM is a signal that is sent from the managing platform to a container or pod that instructs the pod or container to shutdown or restart.  This signal can be sent due to a failed liveness test or a failure inside the container.  SIGTERM allows the container to cleaning and properly shut itself down versus SIGKILL, which we will get to next. Once received, the application will shutdown as quickly as it can, allowing other processes to stop properly and cleaning up other files.  Each application will have a different shutdown time based on the tasks needed to be done.
 
 ### SIGKILL
 


### PR DESCRIPTION
changing from SIGKILL to SIGTERM in:
SIGTERM allows the container to cleaning and properly shut itself down versus SIGKILL, which we will get to next.